### PR TITLE
Modifications to make work with my WP export

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function wordpressImport(backupXmlFile, outputDir){
 
                     published = post.pubDate;
                     comments = post['wp:comment'];
-                    fname = post["wp:post_name"];
+                    fname = post["wp:post_name"][0] || post["wp:post_id"];
                     markdown = '';
                     // if (post.guid && post.guid[0] && post.guid[0]['_']){
                     //     fname = path.basename(post.guid[0]['_']);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,14 @@ const xml2js = require('xml2js');
 const TurndownService = require('turndown');
 var moment = require('moment');
 
-var tds = new TurndownService()
+var tds = new TurndownService({ codeBlockStyle: 'fenced', fence: '```' })
+
+tds.addRule('wppreblock', {
+    filter: ['pre'],
+    replacement: function(content) {
+        return '```\n' + content + '\n```'
+    }
+})
 
 // console.log(`No. of arguments passed: ${process.argv.length}`);
 
@@ -111,7 +118,7 @@ function wordpressImport(backupXmlFile, outputDir){
                 posts.forEach(function(post){
                     var postMap = {};
 
-                    title = post.title[0];
+                    title = post.title[0].trim();
                     
                     // console.log(title);
 


### PR DESCRIPTION
Had a couple changes I needed to make so things came out of my WP export correctly. Here's to hoping someone else might find them useful.

Quick explanation of changes:
* Turn on code fencing with ` ``` `
  * Make a custom rule to also do this for `<pre>` blocks since WP didn't mark it as code and turndown didn't mark it
  * This change might not be helpful to everyone but since I have a lot of code snippets I needed it in my case
* Trim titles b/c somehow they got a ton of whitespace added to them
* Fallback to `wp:post_id` if it gets a blank `wp:post_name`

Thank you for making this useful script!