### PR TITLE
Add current Blogger URL as 'aliases' entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,7 +342,9 @@ function bloggerImport(backupXmlFile, outputDir){
 
                         console.log("\n\n\n\n\n");
 
-                        fileHeader = `---\ntitle: '${title}'\ndate: ${published}\ndraft: false\n${tagString}---\n`;
+                        var alias = url.replace(/^.*\/\/[^\/]+/, '');
+
+                        fileHeader = `---\ntitle: '${title}'\ndate: ${published}\ndraft: false\naliases: [ "${alias}" ]\n${tagString}---\n`;
                         fileContent = `${fileHeader}\n${markdown}`;
 
                         postMap.header = fileHeader;


### PR DESCRIPTION
Include the current URL so existing links to each post will be
redirected to the new Hugo URL. Hugo expects the leading slash, so
only remove the domain.