### PR TITLE
Add support to handle WordPress poosts with non-HTML newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ node index.js w your-wordpress-backup-export.xml out m
 If converting from WordPress, and you have posts that do not contain HTML, you can use a `paragraph-fix` flag at the end.
 
 ```
-node index.js w your-wordpress-backup-export.xml out m
+node index.js w your-wordpress-backup-export.xml out m paragraph-fix
 ```
 
 ## Installation (usual node project)

--- a/README.md
+++ b/README.md
@@ -8,21 +8,26 @@
 For Blogger imports, blog posts and comments (as seperate file `<postname>-comments.md`) will be created in "`out`" directory
 
 ```
-    node index.js b your-blogger-backup-export.xml out
+node index.js b your-blogger-backup-export.xml out
 ```
 
 For WordPress imports, blog posts and comments (as seperate file `<postname>-comments.md`) will be created in "`out`" directory
 
 ```
-    node index.js w your-wordpress-backup-export.xml out
+node index.js w your-wordpress-backup-export.xml out
 ```
 
 If you want the comments to be merged in your post file itself. you can use flag `m` at the end. Defaults to `s` for seperate comments file
 
 ```
-    node index.js w your-wordpress-backup-export.xml out m
+node index.js w your-wordpress-backup-export.xml out m
 ```
 
+If converting from WordPress, and you have posts that do not contain HTML, you can use a `paragraph-fix` flag at the end.
+
+```
+node index.js w your-wordpress-backup-export.xml out m
+```
 
 ## Installation (usual node project)
 

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function wordpressImport(backupXmlFile, outputDir){
                     
                     if (post["content:encoded"]){
                         // console.log('content available');
-                        var postContent = post["content:encoded"];
+                        var postContent = post["content:encoded"].toString();
                         if (applyParagraphFix && !/<p>/i.test(postContent)) {
                             postContent = '<p>' + postContent.replace(/(\r?\n){2}/g, '</p>\n\n<p>') + '</p>';
                         }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ var inputFile =  process.argv[3];
 var outputDir = process.argv[4];
 
 var mergeComments = (process.argv[5] == 'm')?'m':'s' ;
-
+/** Apply a fix to WordPress posts to convert newlines to paragraphs. */
+var applyParagraphFix = (process.argv.indexOf('paragraph-fix') >= 0);
 
 
 if (fs.existsSync(outputDir)) {
@@ -170,7 +171,11 @@ function wordpressImport(backupXmlFile, outputDir){
                     
                     if (post["content:encoded"]){
                         // console.log('content available');
-                        content = '<div>'+post["content:encoded"]+'</div>'; //to resolve error if plain text returned
+                        var postContent = post["content:encoded"];
+                        if (applyParagraphFix && !/<p>/i.test(postContent)) {
+                            postContent = '<p>' + postContent.replace(/(\r?\n){2}/g, '</p>\n\n<p>') + '</p>';
+                        }
+                        content = '<div>'+postContent+'</div>'; //to resolve error if plain text returned
                         markdown = tds.turndown(content);
                         // console.log(markdown);
 


### PR DESCRIPTION
Should resolve https://github.com/palaniraja/blog2md/issues/13.

Based upon a fix in https://github.com/hexojs/hexo-migrator-wordpress/pull/79

Open to any suggestions on tweaks to make this fit the current application (I didn't want to be the one that makes a call on the shortened argument name.)